### PR TITLE
feat: Avoid dockerhub rate limits with GCR mirror

### DIFF
--- a/ci-runner/Dockerfile
+++ b/ci-runner/Dockerfile
@@ -31,6 +31,10 @@ RUN (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.27.0/pac
 COPY --from=build-env /go/bin/cirunner .
 COPY ./ssh-config /root/.ssh/config
 RUN chmod 644 /root/.ssh/config
+RUN mkdir -p /etc/docker
+COPY docker-daemon.json /etc/docker/daemon.json
+RUN mkdir -p /root/.docker/buildx
+COPY buildkitd.default.toml /root/.docker/buildx/buildkitd.default.toml
 
 # passing PARENT_MODE as argument to cirunner as default behavior
 ENTRYPOINT ["./cirunner", "PARENT_MODE"]

--- a/ci-runner/buildkitd.default.toml
+++ b/ci-runner/buildkitd.default.toml
@@ -1,0 +1,2 @@
+[registry."docker.io"]
+  mirrors = ["mirror.gcr.io"]

--- a/ci-runner/docker-daemon.json
+++ b/ci-runner/docker-daemon.json
@@ -1,0 +1,1 @@
+{"registry-mirrors": ["https://mirror.gcr.io"]}


### PR DESCRIPTION
Fix docker hub rate limiting using GCR mirrors