### PR TITLE
fix: getting git repo name from git url func improved to cover all corner cases

### DIFF
--- a/common-lib/git-manager/GitCliManager.go
+++ b/common-lib/git-manager/GitCliManager.go
@@ -290,7 +290,7 @@ func (impl *GitCliManagerImpl) Clone(gitContext GitContext, prj CiProjectDetails
 		logrus.Error("could not clone repo ", "msgMsg: ", msgMsg, " err: ", cErr)
 		return "", msgMsg, cErr
 	}
-	projectName := util.GetProjectName(prj.GitRepository)
+	projectName := util.GetGitRepoNameFromGitRepoUrl(prj.GitRepository)
 	projRootDir := filepath.Join(checkoutPath, projectName)
 
 	_, msgMsg, cErr = impl.moveFilesFromSourceToDestination(projRootDir, checkoutPath)

--- a/common-lib/git-manager/util/Util.go
+++ b/common-lib/git-manager/util/Util.go
@@ -139,15 +139,6 @@ func ParseUrl(rawURL string) (parsedURL *url.URL, err error) {
 	return parsedURL, err
 }
 
-// GetProjectName this function has been designed for returning project name of git-lab and git-hub providers only
-// do not remove this function
-func GetProjectName(url string) string {
-	//if url = https://github.com/devtron-labs/git-sensor.git then it will return git-sensor
-	projName := strings.Split(url, ".")[1]
-	projectName := projName[strings.LastIndex(projName, "/")+1:]
-	return projectName
-}
-
 func GetGitRepoNameFromGitRepoUrl(gitRepoUrl string) string {
 	gitRepoUrl = gitRepoUrl[strings.LastIndex(gitRepoUrl, "/")+1:]
 	return strings.TrimSuffix(gitRepoUrl, ".git")

--- a/common-lib/git-manager/util/Util.go
+++ b/common-lib/git-manager/util/Util.go
@@ -148,4 +148,9 @@ func GetProjectName(url string) string {
 	return projectName
 }
 
+func GetGitRepoNameFromGitRepoUrl(gitRepoUrl string) string {
+	gitRepoUrl = gitRepoUrl[strings.LastIndex(gitRepoUrl, "/")+1:]
+	return strings.TrimSuffix(gitRepoUrl, ".git")
+}
+
 const DEVTRON = "DEVTRON"


### PR DESCRIPTION
handling all corner cases in func which returns git repo name from git url, and replacing previous func usage as it did not handle all corner cases