### PR TITLE
fix: handle force-deleted pods: add detection and handling logic for nodes associated with force-deleted pods and update related messaging

### DIFF
--- a/kubewatch/pkg/informer/bean/bean.go
+++ b/kubewatch/pkg/informer/bean/bean.go
@@ -30,6 +30,7 @@ const (
 
 	ExitCode143Error   = "Error (exit code 143)"
 	NodeNoLongerExists = "PodGC: node no longer exists"
+	NodeForceDeleted   = "Pod was force deleted"
 	UpdateEvent        = "update_event"
 	DeleteEvent        = "delete_event"
 

--- a/kubewatch/pkg/informer/cluster/systemExec/util.go
+++ b/kubewatch/pkg/informer/cluster/systemExec/util.go
@@ -82,6 +82,15 @@ func isResourceNotFoundErr(err error) bool {
 	return false
 }
 
+// isPodForceDeletedWhileRunning checks if a pod was force deleted based on deletion metadata
+func isPodForceDeletedWhileRunning(pod *coreV1.Pod) bool {
+	//For reference all pod phases that exists :- https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+	if (pod.Status.Phase == coreV1.PodRunning || pod.Status.Phase == coreV1.PodPending) && pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil && *pod.DeletionGracePeriodSeconds == 0 {
+		return true
+	}
+	return false
+}
+
 func getWorkflowStatus(podObj *coreV1.Pod, nodeStatus v1alpha1.NodeStatus, templateName string) *informerBean.CiCdStatus {
 	workflowStatus := &informerBean.CiCdStatus{
 		WorkflowStatus: &v1alpha1.WorkflowStatus{},


### PR DESCRIPTION
handle force-deleted pods: add detection and handling logic for nodes associated with force-deleted pods and update related messaging
Fixes: https://github.com/devtron-labs/sprint-tasks/issues/2434